### PR TITLE
101 - Make calendar show ND In Tech one only (remove user's personal calendar)

### DIFF
--- a/src/events.html
+++ b/src/events.html
@@ -7,7 +7,7 @@ description: Neurodiversity in Tech scheduled events
 <h1>Events</h1>
 <iframe
   class="calendar"
-  src="https://calendar.google.com/calendar/embed?&showCalendars=0&showPrint=0&showDate=0&showNav=0&showTitle=0&src=bmRpdGNvbW11bml0eUBnbWFpbC5jb20&src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t"
+  src="https://calendar.google.com/calendar/embed?&showCalendars=0&showPrint=0&showDate=0&showNav=0&showTitle=0&src=bmRpdGNvbW11bml0eUBnbWFpbC5jb20"
   scrolling="no"
 >
   Loading Google Calendar...


### PR DESCRIPTION
# Make calendar show ND In Tech one only

## Description

Right now, the calendar on the site combines the ND In Tech calendar with the user's personal calendar. This removed code that shows the user's calendar.

[Issue Board Ticket](https://github.com/nditcommunity/nditcommunity.github.io/issues/101)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Infrastucture
- [ ] Other (please clarify): **\_**

## Change log

- Remove `&<personal-cal-code` from calendar embed URL.

## Testing

- Tested locally in `localhost:8080`

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new console warnings.
- [x] I manually tested to prove my fix is effective or that my feature works.
- [x] I have assigned this PR to an [owner](https://github.com/nditcommunity/ndit-website).
