### PR TITLE
Bump node version to v22.12.0

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14.17.6']
+        node-version: ['22.12.0']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14.17.6']
+        node-version: ['22.12.0']
 
     steps:
       - uses: actions/checkout@v3

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -8,8 +8,8 @@
 /* colors */
 
 :root {
-  --font-stack: 'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica,
-    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-stack: 'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 
   /* currently used colors */
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -8,8 +8,8 @@
 /* colors */
 
 :root {
-  --font-stack: 'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
-    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-stack: 'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 
   /* currently used colors */
 


### PR DESCRIPTION
# Issue Name Here

## Description

Bumping the version of node used in CI from 14 to 22 (latest LTS version).
This pulls in a newer version of prettier which will unblock a formatting issue which came up on https://github.com/nditcommunity/nditcommunity.github.io/pull/102.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Infrastructure
- [X] Other (please clarify): resolve a code formatting false positive

## Change log

- Bumped node version to 22.12.0
- ran `npm run prettier:write`

## Testing

- How did you test this? Brief check running locally

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new console warnings.
- [ ] I manually tested to prove my fix is effective or that my feature works.
- [ ] I have assigned this PR to an [owner](https://github.com/nditcommunity/ndit-website).
