### PR TITLE
Update staging info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ npm run dev
 
 The development site is available at `http://localhost:8080`.
 
+The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
+
 ## Make a focused change
 
 - Keep the pull request limited to one issue or closely related group of changes.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ is a neurodivergent-led community for people working in and around technology.
 The site is a static [Eleventy](https://www.11ty.dev/) project built with Liquid templates, HTML, CSS, and
 client-side JavaScript. Netlify is the canonical hosting and deployment platform.
 
+The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
+
 ## Quick start
 
 ### Requirements


### PR DESCRIPTION
# Summary

## Description

Add the current Netlify staging URL to the project documentation so contributors can find the latest build from `main`. Legacy staging information is not included.

## Related issue

Closes #119

## Type of change

- [x] Documentation

## Changes

- Add the staging site link to `README.md`
- Add the staging site link to `CONTRIBUTING.md`

## Testing

- `npm audit --omit=optional`
- `npm test` (48 tests passed)
- `npx prettier --check README.md CONTRIBUTING.md`
- Verified `https://ndit-staging.netlify.app` returns HTTP 200

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests where appropriate.
- [x] My changes introduce no new browser console errors or warnings.
- [x] I have checked relevant UI changes on mobile and desktop in light and dark modes.
- [x] I have checked relevant UI changes with keyboard navigation.
- [x] I ran `npm test` and formatting checks locally.
- [x] I have removed tracking parameters from any links I added.