### PR TITLE
Bump the github-actions group with 3 updates

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Use project Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Use project Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,10 +10,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Use project Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload browser test report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/


### PR DESCRIPTION
## Summary

Recreates the GitHub Actions dependency updates from #114 on the original Dependabot branch, targeting the `116-security-updates` integration branch.

Updates:
- `actions/checkout` from v4 to v7
- `actions/setup-node` from v4 to v7
- `actions/upload-artifact` from v4 to v7

Related to #116.

## Testing

- `npm audit --omit=optional` — 0 vulnerabilities
- `npm test` — 48 tests passed
- Confirmed the committed workflow files match the original #114 update exactly