### PR TITLE
Revert "Update staging info"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,6 @@ npm run dev
 
 The development site is available at `http://localhost:8080`.
 
-The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
-
 ## Make a focused change
 
 - Keep the pull request limited to one issue or closely related group of changes.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ is a neurodivergent-led community for people working in and around technology.
 The site is a static [Eleventy](https://www.11ty.dev/) project built with Liquid templates, HTML, CSS, and
 client-side JavaScript. Netlify is the canonical hosting and deployment platform.
 
-The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
-
 ## Quick start
 
 ### Requirements


### PR DESCRIPTION
## Summary

Reverts #120 so the staging documentation changes can be proposed against the `116-security-updates` integration branch instead of landing directly on `main`.

## Changes

- Remove the staging link added to `README.md`
- Remove the staging link added to `CONTRIBUTING.md`

## Testing

- `npm audit --omit=optional` — 0 vulnerabilities
- `npm test` — 48 tests passed
- `git diff --check`