### PR TITLE
Update staging info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ npm run dev
 
 The development site is available at `http://localhost:8080`.
 
+The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
+
 ## Make a focused change
 
 - Keep the pull request limited to one issue or closely related group of changes.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ is a neurodivergent-led community for people working in and around technology.
 The site is a static [Eleventy](https://www.11ty.dev/) project built with Liquid templates, HTML, CSS, and
 client-side JavaScript. Netlify is the canonical hosting and deployment platform.
 
+The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
+
 ## Quick start
 
 ### Requirements


### PR DESCRIPTION
## Summary

Recreates the staging documentation update from #120 on its original branch, targeting the `116-security-updates` integration branch.

## Changes

- Add the current staging site link to `README.md`
- Add the current staging site link to `CONTRIBUTING.md`

Related to #119.

## Testing

- `npm audit --omit=optional` — 0 vulnerabilities
- `npm test` — 48 tests passed
- `git diff --check`
- Confirmed the committed documentation files match the original #120 update exactly