### PR TITLE
Resolve CI runtime warnings

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm test
 
       - name: Upload browser test report
-        if: failure()
+        if: ${{ failure() && hashFiles('playwright-report/**') != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary

Resolve the remaining misleading CI warning from issue #125. The Node 20 deprecation warning is already addressed by the Actions v7 upgrades in the `116-security-updates` base branch.

## Changes

- Upload a Playwright report only when a failed run actually produced report files
- Avoid the `No files were found` artifact warning when an earlier quality step fails

## Documentation

No documentation update is needed. The project continues to use supported Node.js 22.12; the reported deprecation concerned the internal runtime of older GitHub Actions.

## Testing

- `npx prettier --check .github/workflows/quality.yml`
- `npm audit --omit=optional` — 0 vulnerabilities
- `npm test` — 48 tests passed
- `git diff --check`

Closes #125.