### PR TITLE
Revert updates that should land through security branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,6 @@ npm run dev
 
 The development site is available at `http://localhost:8080`.
 
-The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
-
 ## Make a focused change
 
 - Keep the pull request limited to one issue or closely related group of changes.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ is a neurodivergent-led community for people working in and around technology.
 The site is a static [Eleventy](https://www.11ty.dev/) project built with Liquid templates, HTML, CSS, and
 client-side JavaScript. Netlify is the canonical hosting and deployment platform.
 
-The latest build from `main` is available on the [staging site](https://ndit-staging.netlify.app).
-
 ## Quick start
 
 ### Requirements

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,9 +166,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Restore `main` to the state where only the corrective revert of PR #114 remains, so the actual documentation and security updates appear in consolidated PR #124 from `116-security-updates`.

## Reverts from main

- Remove the staging link added to `README.md` by #120
- Remove the staging link added to `CONTRIBUTING.md` by #120
- Revert the standalone `js-yaml` lockfile fix that was appended to #117

The revert of PR #114 remains on `main`, keeping the unwanted Actions v7 update reversed until PR #124 lands the reviewed consolidated updates.

## Expected temporary check state

`npm audit` will report the high-severity `js-yaml` advisory on this revert PR. That is expected because the patched lockfile versions are intentionally being moved into PR #124. After this PR is merged, #124 will show the documentation additions and `js-yaml` patches in its Files changed view.

## Verification

- `git diff --check`
- Confirmed the diff contains only README, CONTRIBUTING, and `js-yaml` lockfile reversions